### PR TITLE
Update coppercore to 2025

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2024.11.29-beta
+version=2025.0.0-beta

--- a/vision/build.gradle
+++ b/vision/build.gradle
@@ -33,18 +33,21 @@ task(checkAkitInstall, dependsOn: "classes", type: JavaExec) {
 // Defining my dependencies. In this case, WPILib (+ friends), and vendor libraries.
 // Also defines JUnit 5.
 dependencies {
-	implementation 'edu.wpi.first.wpilibj:wpilibj-java:2024.3.2'
-	implementation 'edu.wpi.first.wpilibNewCommands:wpilibNewCommands-java:2024.3.2'
-	implementation 'edu.wpi.first.apriltag:apriltag-java:2024.3.2'
+	def wpilibVersion = "2025.1.1-beta-1"
+	implementation "edu.wpi.first.wpilibj:wpilibj-java:$wpilibVersion"
+	implementation "edu.wpi.first.wpilibNewCommands:wpilibNewCommands-java:$wpilibVersion"
+	implementation "edu.wpi.first.apriltag:apriltag-java:$wpilibVersion"
 
 	//def akitJson = new groovy.json.JsonSlurper().parseText(new File(projectDir.getAbsolutePath() + "/vendordeps/AdvantageKit.json").text)
 	//annotationProcessor "org.littletonrobotics.akit.junction:junction-autolog:$akitJson.version"
-	annotationProcessor "org.littletonrobotics.akit.junction:junction-autolog:3.2.1"
+	def akitVersion = "4.0.0-alpha-1"
+	annotationProcessor "org.littletonrobotics.akit.junction:junction-autolog:$akitVersion"
 
-	implementation 'org.littletonrobotics.akit.junction:junction-core:3.2.1'
+	implementation "org.littletonrobotics.akit.junction:junction-core:$akitVersion"
 
-	implementation 'org.photonvision:photonlib-java:v2024.3.1'
-	implementation 'org.photonvision:photontargeting-java:v2024.3.1'
+	def photonVersion = "v2025.0.0-beta-5"
+	implementation "org.photonvision:photonlib-java:$photonVersion"
+	implementation "org.photonvision:photontargeting-java:$photonVersion"
 
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 

--- a/wpilib_interface/build.gradle
+++ b/wpilib_interface/build.gradle
@@ -39,22 +39,26 @@ task(checkAkitInstall, dependsOn: "classes", type: JavaExec) {
 dependencies {
 	//def akitJson = new groovy.json.JsonSlurper().parseText(new File(projectDir.getAbsolutePath() + "/vendordeps/AdvantageKit.json").text)
 	//annotationProcessor "org.littletonrobotics.akit.junction:junction-autolog:$akitJson.version"
-	annotationProcessor "org.littletonrobotics.akit.junction:junction-autolog:3.2.1"
+
+	def akitVersion = "4.0.0-alpha-1"
+	annotationProcessor "org.littletonrobotics.akit.junction:junction-autolog:$akitVersion"
 
 	implementation project(":monitors")
-	implementation 'org.littletonrobotics.akit.junction:junction-core:3.2.1'
-	implementation 'edu.wpi.first.wpilibj:wpilibj-java:2024.3.2'
-	implementation 'edu.wpi.first.wpiutil:wpiutil-java:2024.3.2'
-	implementation 'edu.wpi.first.wpilibNewCommands:wpilibNewCommands-java:2024.3.2'
-	implementation 'edu.wpi.first.wpiunits:wpiunits-java:2024.3.2'
-	implementation 'edu.wpi.first.wpimath:wpimath-java:2024.3.2'
+	implementation "org.littletonrobotics.akit.junction:junction-core:$akitVersion"
+
+	def wpilibVersion = "2025.1.1-beta-1"
+	implementation "edu.wpi.first.wpilibj:wpilibj-java:$wpilibVersion"
+	implementation "edu.wpi.first.wpiutil:wpiutil-java:$wpilibVersion"
+	implementation "edu.wpi.first.wpilibNewCommands:wpilibNewCommands-java:$wpilibVersion"
+	implementation "edu.wpi.first.wpiunits:wpiunits-java:$wpilibVersion"
+	implementation "edu.wpi.first.wpimath:wpimath-java:$wpilibVersion"
 
 	implementation project(":math")
 
-	testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testImplementation "org.junit.jupiter:junit-jupiter:5.10.1"
+	testRuntimeOnly "org.junit.platform:junit-platform-launcher"
 
-	implementation 'com.googlecode.json-simple:json-simple:1.1.1'
+	implementation "com.googlecode.json-simple:json-simple:1.1.1"
 }
 
 test {

--- a/wpilib_interface/src/main/java/frc/robot/BuildConstants.java
+++ b/wpilib_interface/src/main/java/frc/robot/BuildConstants.java
@@ -2,16 +2,16 @@ package frc.robot;
 
 /** Automatically generated file containing build version information. */
 public final class BuildConstants {
-    public static final String MAVEN_GROUP = "com.github.team401";
+    public static final String MAVEN_GROUP = "io.github.team401.coppercore";
     public static final String MAVEN_NAME = "wpilib_interface";
-    public static final String VERSION = "0.0";
-    public static final int GIT_REVISION = 33;
-    public static final String GIT_SHA = "1b2d554bb5908f70bb23c283af21cbe4da88f822";
-    public static final String GIT_DATE = "2024-11-23 18:34:29 EST";
-    public static final String GIT_BRANCH = "addJSONSaving";
-    public static final String BUILD_DATE = "2024-11-23 18:37:13 EST";
-    public static final long BUILD_UNIX_TIME = 1732405033508L;
-    public static final int DIRTY = 0;
+    public static final String VERSION = "2025.0.0-beta";
+    public static final int GIT_REVISION = 43;
+    public static final String GIT_SHA = "60c0db4808cb5dcf1d9bb3c9a4ba41c86abf1d15";
+    public static final String GIT_DATE = "2024-12-05 12:25:16 EST";
+    public static final String GIT_BRANCH = "2025core";
+    public static final String BUILD_DATE = "2024-12-06 09:44:25 EST";
+    public static final long BUILD_UNIX_TIME = 1733496265888L;
+    public static final int DIRTY = 1;
 
     private BuildConstants() {}
 }


### PR DESCRIPTION
Changes:
- Change all build.gradles that reference advantagekit or wpilib versions to use variables.
- Update wpilib to 2025.1.1-beta-1
- Update advantagekit to 4.0.0-alpha-1
- Change coppercore vision to 2025.0.0-beta