### PR TITLE
add javadocs to vision classes

### DIFF
--- a/vision/src/main/java/coppercore/vision/VisionIO.java
+++ b/vision/src/main/java/coppercore/vision/VisionIO.java
@@ -4,6 +4,11 @@ import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import org.littletonrobotics.junction.AutoLog;
 
+
+/**
+ * Represents an IO wrapper for vision localizer to query. 
+ * This class is responsible for updating camera poses and data
+ */
 public interface VisionIO {
     @AutoLog
     public static class VisionIOInputs {

--- a/vision/src/main/java/coppercore/vision/VisionIOPhotonReal.java
+++ b/vision/src/main/java/coppercore/vision/VisionIOPhotonReal.java
@@ -9,6 +9,9 @@ import java.util.List;
 import java.util.Set;
 import org.photonvision.PhotonCamera;
 
+/**
+ * This class implements io using photon vision
+ */
 public class VisionIOPhotonReal implements VisionIO {
     protected final PhotonCamera camera;
     protected final Transform3d robotToCamera;

--- a/vision/src/main/java/coppercore/vision/VisionIOPhotonSim.java
+++ b/vision/src/main/java/coppercore/vision/VisionIOPhotonSim.java
@@ -8,6 +8,9 @@ import org.photonvision.simulation.PhotonCameraSim;
 import org.photonvision.simulation.SimCameraProperties;
 import org.photonvision.simulation.VisionSystemSim;
 
+/**
+ * implements vision io throuigh photon vision simulation
+ */
 public class VisionIOPhotonSim extends VisionIOPhotonReal {
     private static VisionSystemSim visionSim;
 


### PR DESCRIPTION
- javadocs now added to all vision methods
- explanations regarding difficult methods embedded within code

this is updated from josh' vision docs due to migration to advantage kit vision template