### PR TITLE
add single tag pose estimation

### DIFF
--- a/vision/build.gradle
+++ b/vision/build.gradle
@@ -25,11 +25,8 @@ def includeDesktopSupport = true
 // Configuration for AdvantageKit
 repositories {
 	maven {
-		url = uri("https://maven.pkg.github.com/Mechanical-Advantage/AdvantageKit")
-		credentials {
-			username = "Mechanical-Advantage-Bot"
-			password = "\u0067\u0068\u0070\u005f\u006e\u0056\u0051\u006a\u0055\u004f\u004c\u0061\u0079\u0066\u006e\u0078\u006e\u0037\u0051\u0049\u0054\u0042\u0032\u004c\u004a\u006d\u0055\u0070\u0073\u0031\u006d\u0037\u004c\u005a\u0030\u0076\u0062\u0070\u0063\u0051"
-		}
+		// AdvantageKit maven repository
+		url "https://frcmaven.wpi.edu/artifactory/littletonrobotics-mvn-release/"
 	}
 	mavenLocal()
 }

--- a/vision/src/main/java/coppercore/vision/CoreVisionConstants.java
+++ b/vision/src/main/java/coppercore/vision/CoreVisionConstants.java
@@ -11,7 +11,7 @@ public final class CoreVisionConstants {
     public static final double maxAcceptedDistanceMeters = 10.0;
     public static final double linearStdDevFactor = 0.02;
     public static final double angularStdDevFactor = 0.06;
-    public static final double singleTagDistanceCutoff = 4.0;
     public static final double distanceFactor = 1.0;
     public static final double maxZCutoff = 1.0;
+    public static final double maxSingleTagAmbiguity = 0.3;
 }

--- a/vision/src/main/java/coppercore/vision/VisionLocalizer.java
+++ b/vision/src/main/java/coppercore/vision/VisionLocalizer.java
@@ -123,9 +123,7 @@ public class VisionLocalizer extends SubsystemBase {
     private boolean shouldRejectPose(VisionIO.PoseObservation observation) {
         return observation.tagCount() == 0 // Must have at least one tag
                 || (observation.tagCount() == 1
-                        && observation.averageTagDistance()
-                                > CoreVisionConstants
-                                        .singleTagDistanceCutoff) // Cannot be high ambiguity
+                        && observation.ambiguity() > 0.3) // Cannot be high ambiguity if single tag
                 || Math.abs(observation.pose().getZ())
                         > CoreVisionConstants.maxZCutoff // Must have realistic Z coordinate
                 || observation.averageTagDistance() > CoreVisionConstants.maxAcceptedDistanceMeters

--- a/vision/src/main/java/coppercore/vision/VisionLocalizer.java
+++ b/vision/src/main/java/coppercore/vision/VisionLocalizer.java
@@ -123,7 +123,7 @@ public class VisionLocalizer extends SubsystemBase {
     private boolean shouldRejectPose(VisionIO.PoseObservation observation) {
         return observation.tagCount() == 0 // Must have at least one tag
                 || (observation.tagCount() == 1
-                        && observation.ambiguity() > 0.3) // Cannot be high ambiguity if single tag
+                        && observation.ambiguity() > CoreVisionConstants.maxSingleTagAmbiguity) // Cannot be high ambiguity if single tag
                 || Math.abs(observation.pose().getZ())
                         > CoreVisionConstants.maxZCutoff // Must have realistic Z coordinate
                 || observation.averageTagDistance() > CoreVisionConstants.maxAcceptedDistanceMeters


### PR DESCRIPTION
- add else if conditional for single tag result to VisionIOPhotonReal
- add transformation from that target pose to robot pose
- add ambiguity check to shouldRejectPose method in VisionLocalizer (max ambiguity set to 0.3)
- DOES NOT add single tag rejection based on which camera sees it (will be added if needed once we find location of cameras)

resolves #85 