### PR TITLE
Add Asymmetric Debouncer

### DIFF
--- a/wpilib_interface/build.gradle
+++ b/wpilib_interface/build.gradle
@@ -68,6 +68,8 @@ test {
 	useJUnitPlatform()
 	systemProperty 'junit.jupiter.extensions.autodetection.enabled', 'true'
 }
+// injects the JNI extraction dir into java.library.path for tests.
+wpi.java.configureTestTasks(test)
 
 // Simulation configuration (e.g. environment variables).
 //

--- a/wpilib_interface/src/main/java/coppercore/wpilib_interface/AsymmetricDebouncer.java
+++ b/wpilib_interface/src/main/java/coppercore/wpilib_interface/AsymmetricDebouncer.java
@@ -6,8 +6,12 @@ import edu.wpi.first.math.filter.Debouncer.DebounceType;
 /**
  * An asymmetric debouncer: debounces both the rising and falling edge and allows for having
  * different rise and fall times.
+ *
+ * <p>Debouncers will initialize to {@code false} as their initial/baseline state.
  */
 public class AsymmetricDebouncer {
+    private boolean lastOutput = false;
+
     private final Debouncer riseDebouncer;
     private final Debouncer fallDebouncer;
 
@@ -34,12 +38,17 @@ public class AsymmetricDebouncer {
         boolean riseOutput = riseDebouncer.calculate(input);
         boolean fallOutput = fallDebouncer.calculate(input);
 
-        // The output of this method are based on the following possible cases:
-        // Input off -> both off -> output off
-        // Input on -> fall turns on before rise -> output off
-        // Input on -> rise on -> output on
-        // Input off -> rise turns off, fall still on -> output on
-        // Input off -> fall turns off -> output off
-        return riseOutput || (fallOutput && !riseOutput);
+        // The outputs of this method are based on the following possible cases:
+        //  - Input off -> both off -> output off
+        //  - Input on -> fall turns on before rise -> output off
+        //  - Input on -> rise on -> output on
+        //  - Input off -> rise turns off, fall still on -> output on
+        //  - Input off -> fall turns off -> output off
+
+        // The reasoning here is that:
+        //  - If the last output was false, wait for the rise debouncer to let output rise to true
+        //  - If the last output was true, wait for the fall debouncer to let output fall to false
+        lastOutput = (riseOutput && !lastOutput) || (fallOutput && lastOutput);
+        return lastOutput;
     }
 }

--- a/wpilib_interface/src/main/java/coppercore/wpilib_interface/AsymmetricDebouncer.java
+++ b/wpilib_interface/src/main/java/coppercore/wpilib_interface/AsymmetricDebouncer.java
@@ -1,0 +1,39 @@
+import edu.wpi.first.math.filter.Debouncer;
+import edu.wpi.first.math.filter.Debouncer.DebounceType;
+
+public class AsymmetricDebouncer {
+    private final Debouncer riseDebouncer;
+    private final Debouncer fallDebouncer;
+
+    /**
+     * Creates a new AsymmetricDebouncer.
+     *
+     * @param riseTimeSeconds The number of seconds the value must change from false to true for the
+     *     filtered value to change to true.
+     * @param fallTimeSeconds The number of seconds the value must change from true to false for the
+     *     filtered value to change to false.
+     */
+    public AsymmetricDebouncer(double riseTimeSeconds, double fallTimeSeconds) {
+        riseDebouncer = new Debouncer(riseTimeSeconds, DebounceType.kRising);
+        fallDebouncer = new Debouncer(fallTimeSeconds, DebounceType.kFalling);
+    }
+
+    /**
+     * Applies the debouncer to the input stream.
+     *
+     * @param input The current value of the input stream.
+     * @return The debounced value of the input stream.
+     */
+    public boolean calculate(boolean input) {
+        boolean riseOutput = riseDebouncer.calculate(input);
+        boolean fallOutput = fallDebouncer.calculate(input);
+
+        // The output of this method are based on the following possible cases:
+        // Input off -> both off -> output off
+        // Input on -> fall turns on before rise -> output off
+        // Input on -> rise on -> output on
+        // Input off -> rise turns off, fall still on -> output on
+        // Input off -> fall turns off -> output off
+        return riseOutput || (fallOutput && !riseOutput);
+    }
+}

--- a/wpilib_interface/src/main/java/coppercore/wpilib_interface/AsymmetricDebouncer.java
+++ b/wpilib_interface/src/main/java/coppercore/wpilib_interface/AsymmetricDebouncer.java
@@ -3,6 +3,10 @@ package coppercore.wpilib_interface;
 import edu.wpi.first.math.filter.Debouncer;
 import edu.wpi.first.math.filter.Debouncer.DebounceType;
 
+/**
+ * An asymmetric debouncer: debounces both the rising and falling edge and allows for having
+ * different rise and fall times.
+ */
 public class AsymmetricDebouncer {
     private final Debouncer riseDebouncer;
     private final Debouncer fallDebouncer;

--- a/wpilib_interface/src/main/java/coppercore/wpilib_interface/AsymmetricDebouncer.java
+++ b/wpilib_interface/src/main/java/coppercore/wpilib_interface/AsymmetricDebouncer.java
@@ -1,3 +1,5 @@
+package coppercore.wpilib_interface;
+
 import edu.wpi.first.math.filter.Debouncer;
 import edu.wpi.first.math.filter.Debouncer.DebounceType;
 

--- a/wpilib_interface/src/test/java/AsymmetricDebouncerTests.java
+++ b/wpilib_interface/src/test/java/AsymmetricDebouncerTests.java
@@ -17,7 +17,7 @@ class AsymmetricDebouncerTests {
         setMockTimeSeconds(0.0);
     }
 
-    /** Disabler mock time in case some other test requires the real time */
+    /** Disables mock time in case some other test requires the real time */
     @AfterEach
     @SuppressWarnings("unused")
     void disableMockTime() {
@@ -140,7 +140,7 @@ class AsymmetricDebouncerTests {
      * <ul>
      *   <li>Initializes to false
      *   <li>Doesn't rise in under 1.0s
-     *   <li>A single 'false'' signal resets rise time
+     *   <li>A single 'false' signal resets rise time
      *   <li>Rises after >= 1.0s of 'true' signal
      *   <li>Doesn't fall in under 1.5s
      *   <li>A single 'true' signal resets fall time

--- a/wpilib_interface/src/test/java/AsymmetricDebouncerTests.java
+++ b/wpilib_interface/src/test/java/AsymmetricDebouncerTests.java
@@ -1,14 +1,51 @@
-import static edu.wpi.first.units.Units.*;
+import static edu.wpi.first.units.Units.Microseconds;
+import static edu.wpi.first.units.Units.Seconds;
 
 import coppercore.wpilib_interface.AsymmetricDebouncer;
 import edu.wpi.first.util.WPIUtilJNI;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class AsymmetricDebouncerTests {
+class AsymmetricDebouncerTests {
+    /** Enables WPIUtilJNI mock time and set the time to 0.0 seconds */
+    @BeforeEach
+    @SuppressWarnings("unused")
+    void setUpMockTime() {
+        WPIUtilJNI.enableMockTime();
+        setMockTimeSeconds(0.0);
+    }
+
+    /** Disabler mock time in case some other test requires the real time */
+    @AfterEach
+    @SuppressWarnings("unused")
+    void disableMockTime() {
+        WPIUtilJNI.disableMockTime();
+    }
+
+    /**
+     * Set WPIUtilJni's mock time to timeSeconds
+     *
+     * <p>This exists as a wrapper because WPIUtilJNI.setMockTime expects the time as a long in
+     * microseconds
+     *
+     * @param timeSeconds the time to set, in seconds
+     */
+    private void setMockTimeSeconds(double timeSeconds) {
+        WPIUtilJNI.setMockTime((long) Seconds.of(timeSeconds).in(Microseconds));
+    }
+
+    /**
+     * Tests a debouncer with an instant rise and fall time:
+     *
+     * <p>Verifies that the value instantly rises and falls, and remains true/false when passed the
+     * same value multiple times in a row.
+     */
     @Test
-    public void instantRiseAndFall() {
+    void instantRiseAndFall() {
         AsymmetricDebouncer debouncer = new AsymmetricDebouncer(0.0, 0.0);
+
         Assertions.assertFalse(debouncer.calculate(false));
         Assertions.assertTrue(debouncer.calculate(true));
         Assertions.assertFalse(debouncer.calculate(false));
@@ -20,20 +57,130 @@ public class AsymmetricDebouncerTests {
         Assertions.assertTrue(debouncer.calculate(true));
     }
 
+    /**
+     * Tests a debouncer with an instant rise time but a non-instant (1.0s) fall time. Tests that:
+     *
+     * <ul>
+     *   <li>The debouncer initializes to false
+     *   <li>It doesn't fall in less than 1.0 seconds
+     *   <li>An instant of 'true' signal resets the fall timer
+     *   <li>It falls to false >= 1.0 seconds from the last 'true' signal
+     *   <li>It instantly rises back to 'true' on the first 'true' signal
+     * </ul>
+     */
     @Test
-    public void instantRise() {
-        WPIUtilJNI.enableMockTime();
-        WPIUtilJNI.setMockTime((long) Seconds.of(0.0).in(Microseconds));
+    void instantRiseSlowFall() {
         AsymmetricDebouncer debouncer = new AsymmetricDebouncer(0.0, 1.0);
-        Assertions.assertFalse(debouncer.calculate(false)); // Start with false, hasn't risen yet
-        Assertions.assertTrue(debouncer.calculate(true)); // Should rise instantly
-        Assertions.assertTrue(debouncer.calculate(false)); // But should not fall instantly
-        WPIUtilJNI.setMockTime((long) Seconds.of(0.5).in(Microseconds));
-        Assertions.assertTrue(debouncer.calculate(false)); // Should not fall until >=1.0 seconds
-        WPIUtilJNI.setMockTime((long) Seconds.of(1.0).in(Microseconds));
-        Assertions.assertFalse(debouncer.calculate(false)); // Now it should have fallen
-        WPIUtilJNI.setMockTime((long) Seconds.of(1.5).in(Microseconds));
-        Assertions.assertFalse(debouncer.calculate(false));
-        WPIUtilJNI.disableMockTime();
+
+        Assertions.assertFalse(debouncer.calculate(false), "Debouncer must initialize to false.");
+
+        Assertions.assertTrue(
+                debouncer.calculate(true), "0.0s rise time means debouncer should rise instantly");
+
+        setMockTimeSeconds(0.5);
+        Assertions.assertTrue(
+                debouncer.calculate(false), "0.5s < 1.0s fall time, result should remain true");
+
+        // Send in a true value to reset the time on the value falling to false
+        debouncer.calculate(true);
+
+        setMockTimeSeconds(1.0);
+        Assertions.assertTrue(
+                debouncer.calculate(false), "'true' signal should have reset fall time at t=0.5s");
+
+        setMockTimeSeconds(1.5);
+        Assertions.assertFalse(
+                debouncer.calculate(false),
+                "1.5s - 0.5s >= 1.0s fall time, result should fall to false");
+    }
+
+    /**
+     * Tests a debouncer with a non-instant (1.0s) rise time and an instant fall time. Tests that:
+     *
+     * <ul>
+     *   <li>The debouncer initializes to false
+     *   <li>It doesn't rise in less than 1.0 seconds
+     *   <li>An instant of 'false' signal resets the rise timer
+     *   <li>It rises to true >= 1.0 seconds from the last 'false' signal
+     *   <li>It instantly falls back to 'false' on the first 'false' signal
+     * </ul>
+     */
+    @Test
+    void slowRiseInstantFall() {
+        AsymmetricDebouncer debouncer = new AsymmetricDebouncer(1.0, 0.0);
+
+        Assertions.assertFalse(debouncer.calculate(false), "Debouncer must initialize to false.");
+
+        setMockTimeSeconds(0.99);
+        Assertions.assertFalse(
+                debouncer.calculate(true), "0.99s < 1.0s rise time, result should remain false");
+
+        // Send in a false signal to reset the rise timer at 0.99s (will wait until 1.99s to rise
+        // again)
+        debouncer.calculate(false);
+
+        setMockTimeSeconds(1.0);
+        Assertions.assertFalse(
+                debouncer.calculate(true),
+                "'false' signal should have reset rise timer at t=0.99s");
+
+        setMockTimeSeconds(1.99);
+        Assertions.assertTrue(
+                debouncer.calculate(true),
+                "1.99s-0.99s >= 1.0s rise time, result should rise to true");
+
+        Assertions.assertFalse(
+                debouncer.calculate(false), "0.0s fall time means debouncer should fall instantly");
+    }
+
+    /**
+     * Tests a debouncer with a non-instant (1.0s) rise and non-instant (1.5s) fall time. Tests
+     * that:
+     *
+     * <ul>
+     * </ul>
+     */
+    @Test
+    void fastRiseSlowFall() {
+        AsymmetricDebouncer debouncer = new AsymmetricDebouncer(1.0, 1.5);
+
+        Assertions.assertFalse(debouncer.calculate(false), "Debouncer must initialize to false.");
+
+        setMockTimeSeconds(0.99);
+        Assertions.assertFalse(
+                debouncer.calculate(true), "0.99s < 1.0s rise time, signal should remain false");
+
+        // Send a 'false' signal to reset rise time
+        debouncer.calculate(false);
+
+        setMockTimeSeconds(1.0);
+        Assertions.assertFalse(
+                debouncer.calculate(true),
+                "'false' signal should have reset rise timer at t=0.99s");
+
+        setMockTimeSeconds(1.99);
+        Assertions.assertTrue(
+                debouncer.calculate(true),
+                "1.99s - 0.99s >= 1.0s rise time, signal should rise to true");
+
+        Assertions.assertTrue(
+                debouncer.calculate(false), "0.0s < 1.5s fall time, signal should remain true");
+
+        setMockTimeSeconds(3.0);
+        Assertions.assertTrue(
+                debouncer.calculate(false),
+                "3.0s - 1.99s < 1.5s fall time, signal should remain true");
+
+        // Send a 'true' signal to reset fall time
+        debouncer.calculate(true);
+
+        setMockTimeSeconds(3.5);
+        Assertions.assertTrue(
+                debouncer.calculate(false), "'true' signal should have reset fall tiemr at t=3.0s");
+
+        setMockTimeSeconds(5.0);
+        Assertions.assertFalse(
+                debouncer.calculate(false),
+                "5.0s - 3.5s >= 1.5s fall time, signal should fall to false");
     }
 }

--- a/wpilib_interface/src/test/java/AsymmetricDebouncerTests.java
+++ b/wpilib_interface/src/test/java/AsymmetricDebouncerTests.java
@@ -1,10 +1,7 @@
+import static edu.wpi.first.units.Units.*;
+
 import coppercore.wpilib_interface.AsymmetricDebouncer;
-import coppercore.wpilib_interface.UnitUtils;
-import edu.wpi.first.math.MathSharedStore;
-import edu.wpi.first.units.Units;
-
-import java.math.MathContext;
-
+import edu.wpi.first.util.WPIUtilJNI;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -25,22 +22,18 @@ public class AsymmetricDebouncerTests {
 
     @Test
     public void instantRise() {
+        WPIUtilJNI.enableMockTime();
+        WPIUtilJNI.setMockTime((long) Seconds.of(0.0).in(Microseconds));
         AsymmetricDebouncer debouncer = new AsymmetricDebouncer(0.0, 1.0);
-    }
-
-    @Test
-    public void clampBelowBounds() {
-        Assertions.assertTrue(
-                UnitUtils.clampMeasure(
-                                Units.Meters.of(0.0), Units.Meters.of(1.0), Units.Meters.of(3.0))
-                        .equals(Units.Meters.of(1.0)));
-    }
-
-    @Test
-    public void clampAboveBounds() {
-        Assertions.assertTrue(
-                UnitUtils.clampMeasure(
-                                Units.Meters.of(4.0), Units.Meters.of(1.0), Units.Meters.of(3.0))
-                        .equals(Units.Meters.of(3.0)));
+        Assertions.assertFalse(debouncer.calculate(false)); // Start with false, hasn't risen yet
+        Assertions.assertTrue(debouncer.calculate(true)); // Should rise instantly
+        Assertions.assertTrue(debouncer.calculate(false)); // But should not fall instantly
+        WPIUtilJNI.setMockTime((long) Seconds.of(0.5).in(Microseconds));
+        Assertions.assertTrue(debouncer.calculate(false)); // Should not fall until >=1.0 seconds
+        WPIUtilJNI.setMockTime((long) Seconds.of(1.0).in(Microseconds));
+        Assertions.assertFalse(debouncer.calculate(false)); // Now it should have fallen
+        WPIUtilJNI.setMockTime((long) Seconds.of(1.5).in(Microseconds));
+        Assertions.assertFalse(debouncer.calculate(false));
+        WPIUtilJNI.disableMockTime();
     }
 }

--- a/wpilib_interface/src/test/java/AsymmetricDebouncerTests.java
+++ b/wpilib_interface/src/test/java/AsymmetricDebouncerTests.java
@@ -1,0 +1,46 @@
+import coppercore.wpilib_interface.AsymmetricDebouncer;
+import coppercore.wpilib_interface.UnitUtils;
+import edu.wpi.first.math.MathSharedStore;
+import edu.wpi.first.units.Units;
+
+import java.math.MathContext;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class AsymmetricDebouncerTests {
+    @Test
+    public void instantRiseAndFall() {
+        AsymmetricDebouncer debouncer = new AsymmetricDebouncer(0.0, 0.0);
+        Assertions.assertFalse(debouncer.calculate(false));
+        Assertions.assertTrue(debouncer.calculate(true));
+        Assertions.assertFalse(debouncer.calculate(false));
+        Assertions.assertTrue(debouncer.calculate(true));
+        Assertions.assertTrue(debouncer.calculate(true));
+        Assertions.assertFalse(debouncer.calculate(false));
+        Assertions.assertFalse(debouncer.calculate(false));
+        Assertions.assertFalse(debouncer.calculate(false));
+        Assertions.assertTrue(debouncer.calculate(true));
+    }
+
+    @Test
+    public void instantRise() {
+        AsymmetricDebouncer debouncer = new AsymmetricDebouncer(0.0, 1.0);
+    }
+
+    @Test
+    public void clampBelowBounds() {
+        Assertions.assertTrue(
+                UnitUtils.clampMeasure(
+                                Units.Meters.of(0.0), Units.Meters.of(1.0), Units.Meters.of(3.0))
+                        .equals(Units.Meters.of(1.0)));
+    }
+
+    @Test
+    public void clampAboveBounds() {
+        Assertions.assertTrue(
+                UnitUtils.clampMeasure(
+                                Units.Meters.of(4.0), Units.Meters.of(1.0), Units.Meters.of(3.0))
+                        .equals(Units.Meters.of(3.0)));
+    }
+}

--- a/wpilib_interface/src/test/java/AsymmetricDebouncerTests.java
+++ b/wpilib_interface/src/test/java/AsymmetricDebouncerTests.java
@@ -138,6 +138,13 @@ class AsymmetricDebouncerTests {
      * that:
      *
      * <ul>
+     *   <li>Initializes to false
+     *   <li>Doesn't rise in under 1.0s
+     *   <li>A single 'false'' signal resets rise time
+     *   <li>Rises after >= 1.0s of 'true' signal
+     *   <li>Doesn't fall in under 1.5s
+     *   <li>A single 'true' signal resets fall time
+     *   <li>Falls after >= 1.5s of 'false' signal
      * </ul>
      */
     @Test


### PR DESCRIPTION
## Summary

Adds an Asymmetric debouncer class that can debounce a signal on the rising and falling edges with a different debounce time for each edge. This is different from the WPILib Debouncer with mode Both because that debouncer forces you to use the same time for rising and falling.

## Features
- `AsymmetricDebouncer` class under package `coppercore.wpilib_interface` with javadocs
- Unit tests for:
  - Instant rise & fall time
  - Instant rise & non-instant fall time
  - Non-instant rise & instant fall time
  - Non-instant and different rise and fall times
- Adds support for WPIUtilJNI to wpilib_interface by adding `wpi.java.configureTestTasks()` in `build.gradle`