### PR TITLE
(#193) Replace all requests in MotorIOTalonFX with Voltage equivalents

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=2026.1.0
+version=2026.1.1
 systemProp.file.encoding=utf-8

--- a/wpilib_interface/src/test/java/coppercore/wpilib_interface/test/MotorIOCTRETests.java
+++ b/wpilib_interface/src/test/java/coppercore/wpilib_interface/test/MotorIOCTRETests.java
@@ -95,7 +95,7 @@ public class MotorIOCTRETests {
                                             .withKV(0.0)
                                             .withKA(0.0)
                                             .withKG(0.0)
-                                            .withKP(1.0)
+                                            .withKP(2.0)
                                             .withKI(0.0)
                                             .withKD(0.0))
                             .withMotionMagic(


### PR DESCRIPTION
Replace all requests in MotorIOTalonFX with the voltage equivalent and write out withEnableFOC(true) on all of them. While FOC is enabled by default, I find that it makes it more explicit to state it in the code for those curious enough to read it (and I seriously doubt it's impactful to performance).

- Bump version to 2026.1.1