### PR TITLE
(#230) Added support for toggling single tag observation logging

### DIFF
--- a/vision/src/main/java/coppercore/vision/VisionIO.java
+++ b/vision/src/main/java/coppercore/vision/VisionIO.java
@@ -114,4 +114,11 @@ public interface VisionIO {
             AprilTagFieldLayout tagLayout,
             RunOnce tagLayoutRunOnce,
             DoubleFunction<Optional<Transform3d>> robotToCameraAt) {}
+
+    /**
+     * Returns whether or not the camera is logging its single tag observations.
+     *
+     * @return true if the camera io is logging single tag observations
+     */
+    public boolean isLoggingSingleTags();
 }

--- a/vision/src/main/java/coppercore/vision/VisionIOPhotonSim.java
+++ b/vision/src/main/java/coppercore/vision/VisionIOPhotonSim.java
@@ -31,14 +31,17 @@ public class VisionIOPhotonSim extends VisionIOPhotonReal {
      *     such as calibrations, framerate, latency, etc. If these values aren't known or needed,
      *     use {@link VisionIOPhotonSim#VisionIOPhotonSim(String, Supplier,
      *     coppercore.vision.VisionLocalizer.CameraType)} to use defaults instead.
+     * @param logSingleTagObservations Whether or not the individual tag observations should be
+     *     logged
      * @see VisionIOPhotonReal#VisionIOPhotonReal(String)
      */
     public VisionIOPhotonSim(
             String name,
             Supplier<Pose2d> poseSupplier,
             VisionLocalizer.CameraType type,
-            SimCameraProperties simCameraProperties) {
-        super(name);
+            SimCameraProperties simCameraProperties,
+            boolean logSingleTagObservations) {
+        super(name, logSingleTagObservations);
         this.poseSupplier = poseSupplier;
         this.cameraType = type;
 
@@ -48,6 +51,25 @@ public class VisionIOPhotonSim extends VisionIOPhotonReal {
         }
 
         this.cameraProperties = simCameraProperties;
+    }
+
+    /**
+     * Creates a new VisionIOPhotonVisionSim that does not log single tag observations.
+     *
+     * @param name The name of the camera.
+     * @param poseSupplier Supplier for the robot pose to use in simulation.
+     * @param simCameraProperties A SimCameraProperties used to specify camera-specific properties
+     *     such as calibrations, framerate, latency, etc. If these values aren't known or needed,
+     *     use {@link VisionIOPhotonSim#VisionIOPhotonSim(String, Supplier,
+     *     coppercore.vision.VisionLocalizer.CameraType)} to use defaults instead.
+     * @see VisionIOPhotonReal#VisionIOPhotonReal(String)
+     */
+    public VisionIOPhotonSim(
+            String name,
+            Supplier<Pose2d> poseSupplier,
+            VisionLocalizer.CameraType type,
+            SimCameraProperties simCameraProperties) {
+        this(name, poseSupplier, type, simCameraProperties, false);
     }
 
     /**

--- a/vision/src/main/java/coppercore/vision/VisionLocalizer.java
+++ b/vision/src/main/java/coppercore/vision/VisionLocalizer.java
@@ -104,7 +104,14 @@ public class VisionLocalizer extends SubsystemBase {
     }
 
     public enum CameraType {
+        /**
+         * This is a fixed camera type for cameras that have a constant robot to camera transform
+         */
         FIXED,
+        /**
+         * This is a mobile camera type for cameras that must provide a double function of // time
+         * that gives the current robot to camera transform.
+         */
         MOBILE;
     }
 
@@ -205,6 +212,13 @@ public class VisionLocalizer extends SubsystemBase {
             double alongTrackOffsetMeters) {
         // camera not in vision
         if (desiredCameraIndex >= inputs.length) {
+            return new DistanceToTag(0, 0, false);
+        }
+
+        if (!cameras[desiredCameraIndex].io.isLoggingSingleTags()) {
+            System.err.println(
+                    "getDistanceErrorToTag was called without logging single tag observations -"
+                            + " this needs to be set in the camera io constructor");
             return new DistanceToTag(0, 0, false);
         }
 


### PR DESCRIPTION
- updated some of the java doc comments
- added an overload that can tell the camera whether or not its single tag observations should be logged