### PR TITLE
(#237) Copy over all other missing values from old Slot0Configs in setGains

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=2026.2.11
+version=2026.2.12
 systemProp.file.encoding=utf-8

--- a/wpilib_interface/src/main/java/coppercore/wpilib_interface/subsystems/motors/talonfx/MotorIOTalonFX.java
+++ b/wpilib_interface/src/main/java/coppercore/wpilib_interface/subsystems/motors/talonfx/MotorIOTalonFX.java
@@ -819,6 +819,11 @@ public class MotorIOTalonFX extends CanBusMotorControllerBase implements MotorIO
                                 .withKG(kG)
                                 .withKV(kV)
                                 .withKA(kA)
+                                .withGainSchedBehavior(talonFXConfig.Slot0.GainSchedBehavior)
+                                .withGravityArmPositionOffset(
+                                        talonFXConfig.Slot0.GravityArmPositionOffset)
+                                .withStaticFeedforwardSign(
+                                        talonFXConfig.Slot0.StaticFeedforwardSign)
                                 .withGravityType(
                                         config.gravityFeedforwardType
                                                 .toPhoenix6GravityTypeValue()));


### PR DESCRIPTION
Update MotorIOTalonFX.setGains to copy over static feedforward sign, gainscheduler behavior, and gravity arm position offset from the originally passed config.

These values are updated in a copy rather than modified in place to obey the javadocs statement that the talonFX config doesn't need to be copied since it will not be modified.