### PR TITLE
#267 Invoke @AfterJsonLoad on live instance after PUT in JSONHandler

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=2026.2.21
+version=2026.2.22
 systemProp.file.encoding=utf-8

--- a/parameter_tools/src/main/java/coppercore/parameter_tools/json/JSONHandler.java
+++ b/parameter_tools/src/main/java/coppercore/parameter_tools/json/JSONHandler.java
@@ -2,6 +2,7 @@ package coppercore.parameter_tools.json;
 
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
+import coppercore.parameter_tools.json.annotations.AfterJsonLoad;
 import coppercore.parameter_tools.path_provider.PathProvider;
 import edu.wpi.first.hal.HAL;
 import edu.wpi.first.wpilibj.RobotController;
@@ -9,11 +10,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -391,6 +396,7 @@ public final class JSONHandler {
                         () -> {
                             T updatedObject = routeInfo.sync.deserialize(requestBody);
                             copyFields(updatedObject, routeInfo.instance);
+                            invokeAfterJsonLoad(routeInfo.instance);
                             return jsonResponse(routeInfo.sync.serialize());
                         });
         writeResponse(exchange, response);
@@ -487,6 +493,33 @@ public final class JSONHandler {
                 }
             }
             clazz = clazz.getSuperclass();
+        }
+    }
+
+    /**
+     * Invokes the {@link AfterJsonLoad}-annotated method on the given object, if one exists.
+     *
+     * <p>{@link #handlePut} deserializes JSON into a throwaway object and then bulk-copies its
+     * fields onto the live route instance. Gson fires {@code @AfterJsonLoad} on the throwaway
+     * during deserialization, so the live instance never sees its hook run; this method covers that
+     * gap.
+     */
+    private static void invokeAfterJsonLoad(Object obj) {
+        List<Method> methods =
+                Arrays.stream(obj.getClass().getMethods())
+                        .filter(m -> m.isAnnotationPresent(AfterJsonLoad.class))
+                        .toList();
+        if (methods.size() > 1) {
+            throw new RuntimeException(
+                    "Multiple AfterJsonLoad annotations on methods in one class");
+        }
+        if (methods.isEmpty()) {
+            return;
+        }
+        try {
+            methods.get(0).invoke(obj);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            e.printStackTrace();
         }
     }
 

--- a/parameter_tools/src/main/java/coppercore/parameter_tools/json/JSONSyncConfigBuilder.java
+++ b/parameter_tools/src/main/java/coppercore/parameter_tools/json/JSONSyncConfigBuilder.java
@@ -7,6 +7,7 @@ import com.google.gson.LongSerializationPolicy;
 import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
 import coppercore.parameter_tools.json.adapters.PolymorphDeserializer;
+import coppercore.parameter_tools.json.adapters.PolymorphTypeAdapterFactory;
 import edu.wpi.first.math.Pair;
 import java.util.ArrayList;
 import java.util.List;
@@ -40,6 +41,11 @@ public class JSONSyncConfigBuilder {
 
     /** List of custom TypeAdapterFactory instances to be registered. */
     private List<TypeAdapterFactory> typeAdapterFactories = new ArrayList<>();
+
+    /** Creates a builder with the default Coppercore Gson adapter factories. */
+    public JSONSyncConfigBuilder() {
+        addJsonTypeAdapterFactory(new PolymorphTypeAdapterFactory());
+    }
 
     /**
      * Sets whether null fields should be serialized.

--- a/parameter_tools/src/main/java/coppercore/parameter_tools/json/JSONSyncConfigBuilder.java
+++ b/parameter_tools/src/main/java/coppercore/parameter_tools/json/JSONSyncConfigBuilder.java
@@ -139,6 +139,17 @@ public class JSONSyncConfigBuilder {
     }
 
     /**
+     * Adds a custom TypeAdapterFactory.
+     *
+     * @param factory The TypeAdapterFactory to add.
+     * @return The builder instance.
+     */
+    public JSONSyncConfigBuilder addJsonTypeAdapterFactory(TypeAdapterFactory factory) {
+        typeAdapterFactories.add(factory);
+        return this;
+    }
+
+    /**
      * Use the {@see coppercore.parameter_tools.json.annotations.JsonType} annotation to define a
      * way to determine which class to deserialize to.
      *

--- a/parameter_tools/src/main/java/coppercore/parameter_tools/json/JSONTypeAdapterFactory.java
+++ b/parameter_tools/src/main/java/coppercore/parameter_tools/json/JSONTypeAdapterFactory.java
@@ -58,13 +58,7 @@ public class JSONTypeAdapterFactory implements TypeAdapterFactory {
                         throw new RuntimeException(
                                 "Multiple AfterJsonLoad annotations on methods in one class");
                     }
-                    try {
-                        annotatedMethods.get(0).invoke(obj);
-                    } catch (IllegalAccessException
-                            | IllegalArgumentException
-                            | InvocationTargetException e) {
-                        e.printStackTrace();
-                    }
+                    invokeAfterJsonLoad(obj, annotatedMethods.get(0));
                 }
                 return obj;
             }
@@ -74,6 +68,28 @@ public class JSONTypeAdapterFactory implements TypeAdapterFactory {
                 adapter.write(out, value);
             }
         };
+    }
+
+    private void invokeAfterJsonLoad(Object obj, Method method) {
+        try {
+            method.invoke(obj);
+        } catch (IllegalAccessException | IllegalArgumentException e) {
+            throwAfterJsonLoadFailure(obj, method, e);
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause() == null ? e : e.getCause();
+            throwAfterJsonLoadFailure(obj, method, cause);
+        }
+    }
+
+    private void throwAfterJsonLoadFailure(Object obj, Method method, Throwable cause) {
+        String message =
+                "AfterJsonLoad method "
+                        + method.getName()
+                        + " failed for "
+                        + obj.getClass().getName();
+        System.err.println(message);
+        cause.printStackTrace(System.err);
+        throw new RuntimeException(message, cause);
     }
 
     public <T> TypeAdapter<T> getAfterLoadTypeAdapter(

--- a/parameter_tools/src/main/java/coppercore/parameter_tools/json/adapters/PolymorphTypeAdapterFactory.java
+++ b/parameter_tools/src/main/java/coppercore/parameter_tools/json/adapters/PolymorphTypeAdapterFactory.java
@@ -1,0 +1,84 @@
+package coppercore.parameter_tools.json.adapters;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonParser;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import coppercore.parameter_tools.json.annotations.JsonSubtype;
+import coppercore.parameter_tools.json.annotations.JsonType;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+
+/**
+ * A Gson factory for classes annotated with {@link JsonType}.
+ *
+ * <p>This is registered as a {@link TypeAdapterFactory} so polymorphic fields nested inside maps,
+ * lists, arrays, or other objects are dispatched before Gson tries to instantiate an abstract base
+ * class reflectively.
+ */
+public class PolymorphTypeAdapterFactory implements TypeAdapterFactory {
+    @Override
+    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+        Class<? super T> rawType = type.getRawType();
+        JsonType typeAnnotation = rawType.getAnnotation(JsonType.class);
+        if (typeAnnotation == null) {
+            return null;
+        }
+
+        return new TypeAdapter<>() {
+            @Override
+            public T read(JsonReader reader) throws IOException {
+                JsonElement jsonElement = JsonParser.parseReader(reader);
+                if (jsonElement == null || jsonElement.isJsonNull()) {
+                    return null;
+                }
+                if (!jsonElement.isJsonObject()) {
+                    throw new JsonParseException(
+                            "Expected JSON object for polymorphic type " + rawType.getName());
+                }
+
+                JsonObject jsonObject = jsonElement.getAsJsonObject();
+                JsonElement discriminator = jsonObject.get(typeAnnotation.property());
+                if (discriminator == null || discriminator.isJsonNull()) {
+                    throw new JsonParseException(
+                            "Missing polymorphic discriminator "
+                                    + typeAnnotation.property()
+                                    + " for "
+                                    + rawType.getName());
+                }
+
+                String discriminatorValue = discriminator.getAsString();
+                Type targetType =
+                        Arrays.stream(typeAnnotation.subtypes())
+                                .filter(subtype -> subtype.name().equals(discriminatorValue))
+                                .findFirst()
+                                .map(JsonSubtype::clazz)
+                                .orElseThrow(
+                                        () ->
+                                                new JsonParseException(
+                                                        "Unknown subtype "
+                                                                + discriminatorValue
+                                                                + " for "
+                                                                + rawType.getName()));
+
+                return gson.fromJson(jsonElement, targetType);
+            }
+
+            @Override
+            public void write(JsonWriter out, T value) throws IOException {
+                if (value == null) {
+                    out.nullValue();
+                    return;
+                }
+                gson.toJson(value, value.getClass(), out);
+            }
+        };
+    }
+}

--- a/parameter_tools/src/test/java/coppercore/parameter_tools/test/JSONHandlerHttpTests.java
+++ b/parameter_tools/src/test/java/coppercore/parameter_tools/test/JSONHandlerHttpTests.java
@@ -1044,6 +1044,34 @@ public class JSONHandlerHttpTests {
     }
 
     @Test
+    void putRequest_deserializesPolymorphicNestedObjectWithDefaultConfig()
+            throws InterruptedException, ExecutionException, TimeoutException {
+        JSONHandler handler = new JSONHandler(new JSONSyncConfigBuilder().build());
+        PolymorphAfterLoadParent data = new PolymorphAfterLoadParent();
+
+        handler.addRoute("/afterloadpolydefault", data);
+        PolymorphAfterLoadSub.hookedInstances.clear();
+
+        HttpResult response =
+                awaitRequest(
+                        handler,
+                        startRequest(
+                                "PUT",
+                                "/default/afterloadpolydefault",
+                                "{\"entries\":{\"a\":{\"type\":\"Sub\",\"name\":\"first\"}}}"));
+
+        assertEquals(200, response.statusCode, response.body);
+        assertEquals(1, data.entries.size());
+        PolymorphAfterLoadSub sub = (PolymorphAfterLoadSub) data.entries.get("a");
+        assertEquals("first", sub.name);
+        assertEquals(1, sub.counter, "AfterJsonLoad should have run exactly once");
+        assertTrue(
+                PolymorphAfterLoadSub.hookedInstances.contains(sub),
+                "Default JSONSyncConfigBuilder should deserialize polymorphic route data during"
+                        + " handlePut and preserve AfterJsonLoad behavior");
+    }
+
+    @Test
     void putRequest_invokesAfterJsonLoadOnPolymorphicNestedObject_viaTypeAdapterFactory()
             throws InterruptedException, ExecutionException, TimeoutException {
         // Mirrors the production setup in 181-follower-autos: polymorphic dispatch is provided by a

--- a/parameter_tools/src/test/java/coppercore/parameter_tools/test/JSONHandlerHttpTests.java
+++ b/parameter_tools/src/test/java/coppercore/parameter_tools/test/JSONHandlerHttpTests.java
@@ -9,6 +9,7 @@ import com.google.gson.stream.JsonWriter;
 import coppercore.parameter_tools.json.JSONHandler;
 import coppercore.parameter_tools.json.JSONSyncConfig;
 import coppercore.parameter_tools.json.JSONSyncConfigBuilder;
+import coppercore.parameter_tools.json.annotations.AfterJsonLoad;
 import coppercore.parameter_tools.path_provider.PathProvider;
 import edu.wpi.first.units.Units;
 import edu.wpi.first.units.measure.Angle;
@@ -21,6 +22,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -63,6 +65,39 @@ public class JSONHandlerHttpTests {
         public Angle[] angles =
                 new Angle[] {Units.Degrees.of(0), Units.Degrees.of(90), Units.Degrees.of(180)};
         public Distance[] distances = new Distance[] {Units.Meters.of(1.0), Units.Meters.of(2.0)};
+    }
+
+    public static class AfterLoadRootData {
+        public int a = 0;
+        public int b = 0;
+        public int sum = 0;
+        public static final List<AfterLoadRootData> hookedInstances =
+                Collections.synchronizedList(new ArrayList<>());
+
+        @AfterJsonLoad
+        public void afterLoad() {
+            sum = a + b;
+            hookedInstances.add(this);
+        }
+    }
+
+    public static class AfterLoadNestedChild {
+        public int x = 0;
+        public int y = 0;
+        public int product = 0;
+        public static final List<AfterLoadNestedChild> hookedInstances =
+                Collections.synchronizedList(new ArrayList<>());
+
+        @AfterJsonLoad
+        public void afterLoad() {
+            product = x * y;
+            hookedInstances.add(this);
+        }
+    }
+
+    public static class AfterLoadParent {
+        public String label = "parent";
+        public AfterLoadNestedChild child = new AfterLoadNestedChild();
     }
 
     public static class ThreadTrackedValue {
@@ -844,5 +879,61 @@ public class JSONHandlerHttpTests {
         assertEquals(200, response.statusCode);
         assertEquals(Thread.currentThread(), callbackThread.get());
         assertTrue(response.body.contains("\"success\":true"));
+    }
+
+    @Test
+    void putRequest_invokesAfterJsonLoadOnLiveRootInstance()
+            throws InterruptedException, ExecutionException, TimeoutException {
+        JSONHandler handler = new JSONHandler();
+        AfterLoadRootData data = new AfterLoadRootData();
+        data.a = 1;
+        data.b = 2;
+
+        handler.addRoute("/afterloadroot", data);
+        AfterLoadRootData.hookedInstances.clear();
+
+        HttpResult response =
+                awaitRequest(
+                        handler,
+                        startRequest("PUT", "/default/afterloadroot", "{\"a\":10,\"b\":20}"));
+
+        assertEquals(200, response.statusCode);
+        assertEquals(10, data.a);
+        assertEquals(20, data.b);
+        assertEquals(30, data.sum);
+        assertTrue(
+                AfterLoadRootData.hookedInstances.contains(data),
+                "AfterJsonLoad should have run on the live route instance, not just a"
+                        + " throwaway");
+    }
+
+    @Test
+    void putRequest_invokesAfterJsonLoadOnNestedObject()
+            throws InterruptedException, ExecutionException, TimeoutException {
+        JSONHandler handler = new JSONHandler();
+        AfterLoadParent data = new AfterLoadParent();
+        data.label = "original";
+        data.child.x = 1;
+        data.child.y = 2;
+
+        handler.addRoute("/afterloadnested", data);
+        AfterLoadNestedChild.hookedInstances.clear();
+
+        HttpResult response =
+                awaitRequest(
+                        handler,
+                        startRequest(
+                                "PUT",
+                                "/default/afterloadnested",
+                                "{\"label\":\"updated\",\"child\":{\"x\":3,\"y\":4}}"));
+
+        assertEquals(200, response.statusCode);
+        assertEquals("updated", data.label);
+        assertEquals(3, data.child.x);
+        assertEquals(4, data.child.y);
+        assertEquals(12, data.child.product);
+        assertTrue(
+                AfterLoadNestedChild.hookedInstances.contains(data.child),
+                "AfterJsonLoad should have run on the nested object now living in the route");
     }
 }

--- a/parameter_tools/src/test/java/coppercore/parameter_tools/test/JSONHandlerHttpTests.java
+++ b/parameter_tools/src/test/java/coppercore/parameter_tools/test/JSONHandlerHttpTests.java
@@ -2,7 +2,13 @@ package coppercore.parameter_tools.test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonParser;
 import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
@@ -10,6 +16,8 @@ import coppercore.parameter_tools.json.JSONHandler;
 import coppercore.parameter_tools.json.JSONSyncConfig;
 import coppercore.parameter_tools.json.JSONSyncConfigBuilder;
 import coppercore.parameter_tools.json.annotations.AfterJsonLoad;
+import coppercore.parameter_tools.json.annotations.JsonSubtype;
+import coppercore.parameter_tools.json.annotations.JsonType;
 import coppercore.parameter_tools.path_provider.PathProvider;
 import edu.wpi.first.units.Units;
 import edu.wpi.first.units.measure.Angle;
@@ -18,11 +26,14 @@ import edu.wpi.first.units.measure.LinearVelocity;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
+import java.lang.reflect.Type;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -98,6 +109,69 @@ public class JSONHandlerHttpTests {
     public static class AfterLoadParent {
         public String label = "parent";
         public AfterLoadNestedChild child = new AfterLoadNestedChild();
+    }
+
+    @JsonType(
+            property = "type",
+            subtypes = {@JsonSubtype(clazz = PolymorphAfterLoadSub.class, name = "Sub")})
+    public abstract static class PolymorphAfterLoadBase {
+        public String type;
+    }
+
+    public static class PolymorphAfterLoadSub extends PolymorphAfterLoadBase {
+        public String name = "";
+        public int counter = 0;
+        public static final List<PolymorphAfterLoadSub> hookedInstances =
+                Collections.synchronizedList(new ArrayList<>());
+
+        @AfterJsonLoad
+        public void afterLoad() {
+            counter++;
+            hookedInstances.add(this);
+        }
+    }
+
+    public static class PolymorphAfterLoadParent {
+        public HashMap<String, PolymorphAfterLoadBase> entries = new HashMap<>();
+    }
+
+    /**
+     * Mirror of frc.robot.util.json.FixedPolymorphTypeAdapterFactory from 181-follower-autos: a
+     * polymorphic dispatcher registered as a TypeAdapterFactory rather than a JsonDeserializer,
+     * which is the form NetworkConfigurableWait flows through in production.
+     */
+    public static class FixedPolymorphFactoryStub implements TypeAdapterFactory {
+        @Override
+        public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
+            Class<?> clazz = typeToken.getRawType();
+            if (clazz.getAnnotation(JsonType.class) == null) {
+                return null;
+            }
+            return new TypeAdapter<T>() {
+                @Override
+                public T read(JsonReader reader) throws IOException {
+                    JsonElement el = JsonParser.parseReader(reader);
+                    JsonType jsonType = clazz.getDeclaredAnnotation(JsonType.class);
+                    String discriminator =
+                            el.getAsJsonObject().get(jsonType.property()).getAsString();
+                    Type sub =
+                            Arrays.stream(jsonType.subtypes())
+                                    .filter(s -> s.name().equals(discriminator))
+                                    .findFirst()
+                                    .orElseThrow(
+                                            () ->
+                                                    new JsonParseException(
+                                                            "Unknown subtype: " + discriminator))
+                                    .clazz();
+                    return gson.fromJson(el, sub);
+                }
+
+                @Override
+                public void write(JsonWriter out, T value) throws IOException {
+                    gson.toJson(value, value.getClass(), out);
+                }
+            };
+        }
     }
 
     public static class ThreadTrackedValue {
@@ -935,5 +1009,173 @@ public class JSONHandlerHttpTests {
         assertTrue(
                 AfterLoadNestedChild.hookedInstances.contains(data.child),
                 "AfterJsonLoad should have run on the nested object now living in the route");
+    }
+
+    @Test
+    void putRequest_invokesAfterJsonLoadOnPolymorphicNestedObject()
+            throws InterruptedException, ExecutionException, TimeoutException {
+        JSONSyncConfig config =
+                new JSONSyncConfigBuilder()
+                        .setUpPolymorphAdapter(PolymorphAfterLoadBase.class)
+                        .build();
+        JSONHandler handler = new JSONHandler(config);
+        PolymorphAfterLoadParent data = new PolymorphAfterLoadParent();
+
+        handler.addRoute("/afterloadpoly", data);
+        PolymorphAfterLoadSub.hookedInstances.clear();
+
+        HttpResult response =
+                awaitRequest(
+                        handler,
+                        startRequest(
+                                "PUT",
+                                "/default/afterloadpoly",
+                                "{\"entries\":{\"a\":{\"type\":\"Sub\",\"name\":\"first\"}}}"));
+
+        assertEquals(200, response.statusCode);
+        assertEquals(1, data.entries.size());
+        PolymorphAfterLoadSub sub = (PolymorphAfterLoadSub) data.entries.get("a");
+        assertEquals("first", sub.name);
+        assertEquals(1, sub.counter, "AfterJsonLoad should have run exactly once");
+        assertTrue(
+                PolymorphAfterLoadSub.hookedInstances.contains(sub),
+                "AfterJsonLoad should have run on the polymorphic nested object now living in"
+                        + " the route");
+    }
+
+    @Test
+    void putRequest_invokesAfterJsonLoadOnPolymorphicNestedObject_viaTypeAdapterFactory()
+            throws InterruptedException, ExecutionException, TimeoutException {
+        // Mirrors the production setup in 181-follower-autos: polymorphic dispatch is provided by a
+        // TypeAdapterFactory (FixedPolymorphTypeAdapterFactory), not by registerTypeAdapter.
+        JSONSyncConfigBuilder builder = new JSONSyncConfigBuilder();
+        JSONSyncConfig base = builder.build();
+        List<TypeAdapterFactory> factories = new ArrayList<>(base.typeAdapterFactories());
+        factories.add(new FixedPolymorphFactoryStub());
+        JSONSyncConfig config =
+                new JSONSyncConfig(
+                        base.serializeNulls(),
+                        base.prettyPrinting(),
+                        base.excludeFieldsWithoutExposeAnnotation(),
+                        base.namingPolicy(),
+                        base.longSerializationPolicy(),
+                        base.primitiveChecking(),
+                        base.primitiveCheckPrintAlert(),
+                        base.primitiveCheckCrash(),
+                        base.typeAdapters(),
+                        factories);
+
+        JSONHandler handler = new JSONHandler(config);
+        PolymorphAfterLoadParent data = new PolymorphAfterLoadParent();
+
+        handler.addRoute("/afterloadpolyfactory", data);
+        PolymorphAfterLoadSub.hookedInstances.clear();
+
+        HttpResult response =
+                awaitRequest(
+                        handler,
+                        startRequest(
+                                "PUT",
+                                "/default/afterloadpolyfactory",
+                                "{\"entries\":{\"a\":{\"type\":\"Sub\",\"name\":\"first\"}}}"));
+
+        assertEquals(200, response.statusCode);
+        assertEquals(1, data.entries.size());
+        PolymorphAfterLoadSub sub = (PolymorphAfterLoadSub) data.entries.get("a");
+        assertEquals("first", sub.name);
+        assertEquals(1, sub.counter, "AfterJsonLoad should have run exactly once");
+        assertTrue(
+                PolymorphAfterLoadSub.hookedInstances.contains(sub),
+                "AfterJsonLoad should have run on the polymorphic nested object dispatched via a"
+                        + " TypeAdapterFactory");
+    }
+
+    /**
+     * Mirrors NetworkConfigurableWait: @AfterJsonLoad enforces a uniqueness invariant by throwing
+     * when an already-seen name is reloaded.
+     */
+    public static class StrictPolymorphSub extends StrictPolymorphBase {
+        public String name = "";
+        public static final java.util.Set<String> usedNames =
+                Collections.synchronizedSet(new java.util.HashSet<>());
+        public static final List<StrictPolymorphSub> hookedInstances =
+                Collections.synchronizedList(new ArrayList<>());
+
+        @AfterJsonLoad
+        public void initialize() {
+            hookedInstances.add(this);
+            if (usedNames.contains(name)) {
+                throw new IllegalArgumentException("Duplicate name: " + name);
+            }
+            usedNames.add(name);
+        }
+    }
+
+    @JsonType(
+            property = "type",
+            subtypes = {@JsonSubtype(clazz = StrictPolymorphSub.class, name = "Strict")})
+    public abstract static class StrictPolymorphBase {
+        public String type;
+    }
+
+    public static class StrictPolymorphParent {
+        public HashMap<String, StrictPolymorphBase> entries = new HashMap<>();
+    }
+
+    @Test
+    void putRequest_secondPut_afterJsonLoadFailureReturnsServerError()
+            throws InterruptedException, ExecutionException, TimeoutException {
+        // Reproduces the NetworkConfigurableWait scenario: file load registers the name; PUT
+        // later rebuilds a throwaway with the same name, so the @AfterJsonLoad invariant trips.
+        // The hook should be invoked and its failure should be surfaced instead of silently
+        // skipped.
+        JSONSyncConfigBuilder builder = new JSONSyncConfigBuilder();
+        JSONSyncConfig base = builder.build();
+        List<TypeAdapterFactory> factories = new ArrayList<>(base.typeAdapterFactories());
+        factories.add(new FixedPolymorphFactoryStub());
+        JSONSyncConfig config =
+                new JSONSyncConfig(
+                        base.serializeNulls(),
+                        base.prettyPrinting(),
+                        base.excludeFieldsWithoutExposeAnnotation(),
+                        base.namingPolicy(),
+                        base.longSerializationPolicy(),
+                        base.primitiveChecking(),
+                        base.primitiveCheckPrintAlert(),
+                        base.primitiveCheckCrash(),
+                        base.typeAdapters(),
+                        factories);
+
+        // Re-register StrictPolymorphSub as a JsonSubtype on a fresh base for this test;
+        // reuse PolymorphAfterLoadBase by dropping a Strict Sub onto it isn't supported
+        // since @JsonType is a class-level annotation. Instead, stash the existing one.
+        StrictPolymorphSub.usedNames.clear();
+        StrictPolymorphSub.hookedInstances.clear();
+
+        JSONHandler handler = new JSONHandler(config);
+        StrictPolymorphParent data = new StrictPolymorphParent();
+        StrictPolymorphSub initial = new StrictPolymorphSub();
+        initial.name = "alpha";
+        // simulate the file-load path having already registered this name
+        StrictPolymorphSub.usedNames.add("alpha");
+
+        data.entries.put("a", initial);
+
+        handler.addRoute("/strictpoly", data);
+
+        HttpResult response =
+                awaitRequest(
+                        handler,
+                        startRequest(
+                                "PUT",
+                                "/default/strictpoly",
+                                "{\"entries\":{\"a\":{\"type\":\"Strict\",\"name\":\"alpha\"}}}"));
+
+        assertEquals(500, response.statusCode);
+        assertTrue(response.body.contains("AfterJsonLoad method initialize failed"));
+        assertEquals(
+                1,
+                StrictPolymorphSub.hookedInstances.size(),
+                "AfterJsonLoad should have been entered once on the throwaway");
     }
 }


### PR DESCRIPTION
handlePut deserialized into a throwaway object (firing @AfterJsonLoad on the discarded copy) and then bulk-copied fields onto the live route instance, so the live instance's post-load hook never ran. Now invoke the hook on the live instance after copyFields.

(this does not address the actual problem raises in issue #267 ; it addresses a separate problem)