### PR TITLE
#273 Bump GitHub Actions to Node.js 24 versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     container: ${{ matrix.container }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: true
           fetch-depth: 0
@@ -30,7 +30,7 @@ jobs:
       - name: Fetch history and metadata
         run: git config --global --add safe.directory /__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           java-version: "17"
           distribution: "temurin"
@@ -38,7 +38,7 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew build --max-workers 1 ${{ matrix.build-options }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: ${{ matrix.artifact-name }}
           path: build/allOutputs
@@ -63,14 +63,14 @@ jobs:
     name: "Build - ${{ matrix.artifact-name }}"
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: true
 
       - name: Fetch all history and metadata
         run: git fetch --prune --unshallow
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           java-version: "17"
           distribution: "temurin"
@@ -84,7 +84,7 @@ jobs:
 
       - name: Upload test reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: test-reports-${{ matrix.artifact-name }}
           path: "**/build/reports/tests/test/**/*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew build --max-workers 1 ${{ matrix.build-options }}
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact-name }}
           path: build/allOutputs
@@ -84,7 +84,7 @@ jobs:
 
       - name: Upload test reports
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: test-reports-${{ matrix.artifact-name }}
           path: "**/build/reports/tests/test/**/*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - container: wpilib/roborio-cross-ubuntu:2024-22.04
+          - container: wpilib/roborio-cross-ubuntu:2025-24.04
             artifact-name: Athena
             build-options: "-Ponlylinuxathena"
           - container: wpilib/ubuntu-base:22.04

--- a/.github/workflows/publish_library.yml
+++ b/.github/workflows/publish_library.yml
@@ -1,38 +1,103 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
-# GitHub recommends pinning actions to a commit SHA.
-# To get a newer version, you will need to update the SHA.
-# You can also reference a tag or branch, but the action may change without warning.
-
 name: Publish to Maven Central
+
 on:
   workflow_dispatch:
   release:
     types: [created]
+
 jobs:
   publish:
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v5
-        with: 
+        with:
           submodules: true
+      - uses: actions/checkout@v5
+        with:
           fetch-depth: 0
 
       - name: Set up Java
         uses: actions/setup-java@v5
         with:
-          java-version: '17'
-          distribution: 'temurin'
+          java-version: "17"
+          distribution: "temurin"
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        uses: gradle/actions/setup-gradle@v6
 
+      - name: Extract version from tag
+        id: version
+        run: |
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      # mavenCentralDeploymentValidation=PUBLISHED in gradle.properties makes the
+      # plugin block until Central reaches PUBLISHED (or fail with error details if
+      # it reaches FAILED), so the Gradle exit code is the real source of truth.
       - name: Publish package
-        run: ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache -PRELEASE_SIGNING_ENABLED=true
+        id: publish
+        run: |
+          ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache \
+            -PRELEASE_SIGNING_ENABLED=true \
+            -PsignAllPublications=true \
+            -Pversion="${{ steps.version.outputs.version }}" \
+            --console=plain \
+            2>&1 | tee publish_output.txt
+          exit ${PIPESTATUS[0]}
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.ORG_GRADLE_PROJECT_MAVENCENTRALUSERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.ORG_GRADLE_PROJECT_MAVENCENTRALPASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGINMEMORYKEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGINMEMORYKEYPASSWORD }}
+
+      - name: Write job summary
+        if: always()
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          if [ "${{ steps.publish.outcome }}" = "success" ]; then
+            echo "## ✅ Maven Central Publish Succeeded" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "**Version:** \`$VERSION\`" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "[🔍 View on Maven Central](https://central.sonatype.com/search?q=io.github.team401.coppercore)" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "## ❌ Maven Central Publish Failed" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "**Version:** \`$VERSION\`  **Run:** [View logs]($RUN_URL)" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### Error Details" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            grep -E "(FAILED|ERROR|Exception|> Task|Could not|Caused by|Execution failed|deployment)" publish_output.txt \
+              | tail -50 >> $GITHUB_STEP_SUMMARY || echo "(no error lines extracted)" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "[🔍 Check Central Portal for deployment status](https://central.sonatype.com/publishing/deployments)" >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Open issue on publish failure
+        if: failure() && github.event_name == 'release'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const tag = context.ref.replace('refs/tags/', '');
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `🚨 Maven Central publish failed: ${tag}`,
+              body: [
+                `The publish workflow failed for release \`${tag}\`.`,
+                '',
+                `**[View the failed run](${runUrl})**`,
+                '',
+                'The error details from Central (if any) will be in the run logs under the "Publish package" step.',
+                '',
+                '[View Central Portal deployments](https://central.sonatype.com/publishing/deployments)',
+              ].join('\n'),
+              labels: ['bug'],
+            });

--- a/.github/workflows/publish_library.yml
+++ b/.github/workflows/publish_library.yml
@@ -16,19 +16,19 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with: 
           submodules: true
           fetch-depth: 0
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
 
       - name: Publish package
         run: ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache -PRELEASE_SIGNING_ENABLED=true

--- a/.github/workflows/stage_library.yml
+++ b/.github/workflows/stage_library.yml
@@ -14,19 +14,19 @@ jobs:
   stage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with: 
           submodules: true
           fetch-depth: 0
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
 
       - name: Stage package on central portal
         run: ./gradlew publishToMavenCentral --no-configuration-cache -PRELEASE_SIGNING_ENABLED=true

--- a/.github/workflows/stage_library.yml
+++ b/.github/workflows/stage_library.yml
@@ -15,18 +15,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-        with: 
+        with:
           submodules: true
           fetch-depth: 0
 
       - name: Set up Java
         uses: actions/setup-java@v5
         with:
-          java-version: '17'
-          distribution: 'temurin'
+          java-version: "17"
+          distribution: "temurin"
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Stage package on central portal
         run: ./gradlew publishToMavenCentral --no-configuration-cache -PRELEASE_SIGNING_ENABLED=true

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,3 @@
-import com.vanniktech.maven.publish.SonatypeHost
 import com.vanniktech.maven.publish.JavaLibrary
 import com.vanniktech.maven.publish.JavadocJar
 
@@ -40,23 +39,23 @@ subprojects {
 		mavenCentral()
 		maven {
 			// FRC/wpilib maven repository
-			url 'https://frcmaven.wpi.edu/artifactory/release/'
+			url = 'https://frcmaven.wpi.edu/artifactory/release/'
 		}
 		maven {
 			// AdvantageKit maven repository
-			url "https://frcmaven.wpi.edu/artifactory/littletonrobotics-mvn-release/"
+			url = "https://frcmaven.wpi.edu/artifactory/littletonrobotics-mvn-release/"
 		}
 		maven {
 			// PhotonVision internal maven repository
-			url "https://maven.photonvision.org/repository/internal"
+			url = "https://maven.photonvision.org/repository/internal"
 		}
 		maven {
 			// PhotonVision snapshots maven repository
-			url "https://maven.photonvision.org/repository/snapshots"
+			url = "https://maven.photonvision.org/repository/snapshots"
 		}
 		maven {
 			// REV maven repository (for REVLib)
-			url "https://maven.revrobotics.com/"
+			url = "https://maven.revrobotics.com/"
 		}
 		gradlePluginPortal()
 		mavenLocal()	// this is local to your machine
@@ -120,8 +119,11 @@ subprojects {
     if (project.name == 'standalone') return
 
     mavenPublishing {
-        configure(new JavaLibrary(new JavadocJar.Javadoc(), true))
-        publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+        configure(new com.vanniktech.maven.publish.JavaLibrary(
+        	new com.vanniktech.maven.publish.JavadocJar.Javadoc(), true))
+    	publishToMavenCentral()   // Central Portal is now the default, no argument needed
+
+
 
         // Project release information.
         coordinates(group, project.name, version)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=2026.2.23
+version=2026.2.24
 systemProp.file.encoding=utf-8

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,4 @@
 version=2026.2.24
 systemProp.file.encoding=utf-8
+org.gradle.configuration-cache=true
+mavenCentralDeploymentValidation=PUBLISHED

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 [versions]
 spotless = "8.1.0"
 gversion = "1.10"
-maven-publish = "0.30.0"
+maven-publish = "0.36.0"
 wpilib = "2026.1.1"
 commons-math3 = "3.6.1"
 guava = "32.1.3-jre"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/metadata/build.gradle
+++ b/metadata/build.gradle
@@ -10,13 +10,14 @@ plugins {
 def generatedDir = layout.buildDirectory.dir("generated/sources/metadata/java/main")
 
 def coppercore = project.group.toString().tokenize('.').last()
+def projectVersion = provider { project.version.toString() }
 def pkg = "${coppercore}.${project.name}"
 
 tasks.register("generateCopperCoreMetadata") {
 	outputs.dir(generatedDir)
 
 	doLast {
-		def v = project.version.toString()
+		def v = projectVersion.get()
 		def base = v.split('-', 2)[0]   // safe for SNAPSHOT later
 		def parts = base.tokenize('.')
 		if (parts.size() != 3) {


### PR DESCRIPTION
Node.js 20 actions are deprecated and will be forced to Node 24 by June 16th, 2026. Update actions to current Node 24 versions:
- actions/checkout v4 -> v5
- actions/setup-java v4 -> v5
- gradle/actions/setup-gradle v4.0.0 -> v6.1.0
- actions/upload-artifact v4 -> v5

Closes #273 